### PR TITLE
Add support to override input accessory view that appears over keyboard.

### DIFF
--- a/MarkupEditor/MarkupWKWebView.swift
+++ b/MarkupEditor/MarkupWKWebView.swift
@@ -782,6 +782,14 @@ public class MarkupWKWebView: WKWebView, ObservableObject {
             handler?()
         }
     }
+
+    /// Supply an accessoryView to override the inputAccesoryView of UIResponder.
+    var accessoryView: UIView?
+    
+    public override var inputAccessoryView: UIView? {
+        // remove/replace the default accessory view
+        return accessoryView
+    }
     
 }
 


### PR DESCRIPTION
Hi @stevengharris, would you consider adding this support to override/remove the input accessory view. Currently it is a read-only value. iOS 13+ has the support to remove the input accessory view by supplying nil.

I have made the PR with the changes.

For reference, here is the accepted answer that the example was found on stackoverflow, which another WYSIWYG editor has added.
https://stackoverflow.com/questions/33853924/removing-wkwebview-accesory-bar-in-swift/58001395#58001395