### PR TITLE
Refactor to allow override of toolbar for toolbar location keyboard

### DIFF
--- a/MarkupEditor/MarkupEditorUIView.swift
+++ b/MarkupEditor/MarkupEditorUIView.swift
@@ -84,12 +84,14 @@ public class MarkupEditorUIView: UIView, MarkupDelegate {
                     toolbar.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor)
                 ])
             } else {
+                let toolbar = MarkupToolbarUIView(markupDelegate: markupDelegate).makeManaged()
                 NSLayoutConstraint.activate([
                     webView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
                     webView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
                     webView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor),
                     webView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor)
                 ])
+                webView.inputAccessoryView = toolbar
             }
         }
     

--- a/MarkupEditor/MarkupEditorUIView.swift
+++ b/MarkupEditor/MarkupEditorUIView.swift
@@ -84,14 +84,14 @@ public class MarkupEditorUIView: UIView, MarkupDelegate {
                     toolbar.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor)
                 ])
             } else {
-                let toolbar = MarkupToolbarUIView(markupDelegate: markupDelegate).makeManaged()
                 NSLayoutConstraint.activate([
                     webView.topAnchor.constraint(equalTo: safeAreaLayoutGuide.topAnchor),
                     webView.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor),
                     webView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor),
                     webView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor)
                 ])
-                webView.inputAccessoryView = toolbar
+                // for the scenario that requires an override of inputAccessoryView
+                webView.inputAccessoryView = MarkupToolbarUIView.inputAccessory(markupDelegate: markupDelegate)
             }
         }
     

--- a/MarkupEditor/MarkupToolbarUIView.swift
+++ b/MarkupEditor/MarkupToolbarUIView.swift
@@ -76,7 +76,10 @@ public class MarkupToolbarUIView: UIView {
     /// Return a MarkupToolbarUIView that is compact, containing the current shared ToolbarContents, but makes sure keyboardButton is present.
     public static func inputAccessory(markupDelegate: MarkupDelegate? = nil) -> MarkupToolbarUIView {
         let contents = ToolbarContents.from(ToolbarContents.shared)
-        return MarkupToolbarUIView(.compact, contents: contents, markupDelegate: markupDelegate, withKeyboardButton: true).makeManaged()
+        let toolbar = MarkupToolbarUIView(.compact, contents: contents, markupDelegate: markupDelegate, withKeyboardButton: true).makeManaged()
+        toolbar.translatesAutoresizingMaskIntoConstraints = false
+        toolbar.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        return toolbar
     }
     
 }

--- a/MarkupEditor/MarkupWKWebView.swift
+++ b/MarkupEditor/MarkupWKWebView.swift
@@ -88,10 +88,7 @@ public class MarkupWKWebView: WKWebView, ObservableObject {
             NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidHide), name: UIResponder.keyboardDidHideNotification, object: nil)
         }
     }
-//    private var markupToolbarUIView: MarkupToolbarUIView? {
-//        get { accessoryView as? MarkupToolbarUIView }
-//        set { self.accessoryView = newValue }
-//    }
+
     private var markupToolbarHeightConstraint: NSLayoutConstraint!
     private var firstResponder: AnyCancellable?
     

--- a/MarkupEditor/MarkupWKWebView.swift
+++ b/MarkupEditor/MarkupWKWebView.swift
@@ -64,9 +64,35 @@ public class MarkupWKWebView: WKWebView, ObservableObject {
     /// Track whether a paste action has been invoked so as to avoid double-invocation per https://developer.apple.com/forums/thread/696525
     var pastedAsync = false
     /// An accessoryView to override the inputAccessoryView of UIResponder.
-    public var accessoryView: UIView?
-//    private var markupToolbarUIView: MarkupToolbarUIView!
-//    private var markupToolbarHeightConstraint: NSLayoutConstraint!
+    public var accessoryView: UIView? {
+        willSet {
+            if newValue != accessoryView {
+                // remove height constraints and notification observers
+                self.markupToolbarHeightConstraint = nil
+                NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+                NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardDidHideNotification, object: nil)
+            }
+        }
+        didSet {
+            guard let accessoryView = accessoryView else {
+                // remove height constraints and notification observers
+                self.markupToolbarHeightConstraint = nil
+                NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardWillShowNotification, object: nil)
+                NotificationCenter.default.removeObserver(self, name: UIResponder.keyboardDidHideNotification, object: nil)
+                return
+            }
+            self.markupToolbarHeightConstraint = NSLayoutConstraint(item: accessoryView, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 1, constant: 0)
+            self.markupToolbarHeightConstraint.isActive = true
+            // Use the keyboard notifications to resize the markupToolbar as the accessoryView
+            NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+            NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidHide), name: UIResponder.keyboardDidHideNotification, object: nil)
+        }
+    }
+//    private var markupToolbarUIView: MarkupToolbarUIView? {
+//        get { accessoryView as? MarkupToolbarUIView }
+//        set { self.accessoryView = newValue }
+//    }
+    private var markupToolbarHeightConstraint: NSLayoutConstraint!
     private var firstResponder: AnyCancellable?
     
     /// Types of content that can be pasted in a MarkupWKWebView
@@ -126,15 +152,7 @@ public class MarkupWKWebView: WKWebView, ObservableObject {
         tintColor = tintColor.resolvedColor(with: .current)
         // Set up the accessoryView to be a MarkupToolbarUIView only if toolbarLocation == .keyboard
         if MarkupEditor.toolbarLocation == .keyboard {
-//            markupToolbarUIView = MarkupToolbarUIView.inputAccessory(markupDelegate: markupDelegate)
-//            markupToolbarUIView.translatesAutoresizingMaskIntoConstraints = false
-//            markupToolbarUIView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-//            markupToolbarHeightConstraint = NSLayoutConstraint(item: markupToolbarUIView!, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 1, constant: 0)
-//            markupToolbarHeightConstraint.isActive = true
-//            accessoryView = markupToolbarUIView
-            // Use the keyboard notifications to resize the markupToolbar as the accessoryView
-//            NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-//            NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidHide), name: UIResponder.keyboardDidHideNotification, object: nil)
+            inputAccessoryView = MarkupToolbarUIView.inputAccessory(markupDelegate: markupDelegate)
         }
         observeFirstResponder()
     }
@@ -345,15 +363,15 @@ public class MarkupWKWebView: WKWebView, ObservableObject {
         }
     }
     
-//    //MARK: Keyboard handling and accessoryView setup
-//
-//    @objc func keyboardWillShow() {
-//        markupToolbarHeightConstraint.constant = MarkupEditor.toolbarStyle.height()
-//    }
-//
-//    @objc private func keyboardDidHide() {
-//        markupToolbarHeightConstraint.constant = 0
-//    }
+    //MARK: Keyboard handling and accessoryView setup
+
+    @objc func keyboardWillShow() {
+        markupToolbarHeightConstraint.constant = MarkupEditor.toolbarStyle.height()
+    }
+
+    @objc private func keyboardDidHide() {
+        markupToolbarHeightConstraint.constant = 0
+    }
     
     //MARK: Overrides
     

--- a/MarkupEditor/MarkupWKWebView.swift
+++ b/MarkupEditor/MarkupWKWebView.swift
@@ -65,8 +65,8 @@ public class MarkupWKWebView: WKWebView, ObservableObject {
     var pastedAsync = false
     /// An accessoryView to override the inputAccessoryView of UIResponder.
     public var accessoryView: UIView?
-    private var markupToolbarUIView: MarkupToolbarUIView!
-    private var markupToolbarHeightConstraint: NSLayoutConstraint!
+//    private var markupToolbarUIView: MarkupToolbarUIView!
+//    private var markupToolbarHeightConstraint: NSLayoutConstraint!
     private var firstResponder: AnyCancellable?
     
     /// Types of content that can be pasted in a MarkupWKWebView
@@ -126,15 +126,15 @@ public class MarkupWKWebView: WKWebView, ObservableObject {
         tintColor = tintColor.resolvedColor(with: .current)
         // Set up the accessoryView to be a MarkupToolbarUIView only if toolbarLocation == .keyboard
         if MarkupEditor.toolbarLocation == .keyboard {
-            markupToolbarUIView = MarkupToolbarUIView.inputAccessory(markupDelegate: markupDelegate)
-            markupToolbarUIView.translatesAutoresizingMaskIntoConstraints = false
-            markupToolbarUIView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
-            markupToolbarHeightConstraint = NSLayoutConstraint(item: markupToolbarUIView!, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 1, constant: 0)
-            markupToolbarHeightConstraint.isActive = true
-            accessoryView = markupToolbarUIView
+//            markupToolbarUIView = MarkupToolbarUIView.inputAccessory(markupDelegate: markupDelegate)
+//            markupToolbarUIView.translatesAutoresizingMaskIntoConstraints = false
+//            markupToolbarUIView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+//            markupToolbarHeightConstraint = NSLayoutConstraint(item: markupToolbarUIView!, attribute: .height, relatedBy: .equal, toItem: nil, attribute: .height, multiplier: 1, constant: 0)
+//            markupToolbarHeightConstraint.isActive = true
+//            accessoryView = markupToolbarUIView
             // Use the keyboard notifications to resize the markupToolbar as the accessoryView
-            NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
-            NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidHide), name: UIResponder.keyboardDidHideNotification, object: nil)
+//            NotificationCenter.default.addObserver(self, selector: #selector(keyboardWillShow), name: UIResponder.keyboardWillShowNotification, object: nil)
+//            NotificationCenter.default.addObserver(self, selector: #selector(keyboardDidHide), name: UIResponder.keyboardDidHideNotification, object: nil)
         }
         observeFirstResponder()
     }
@@ -345,15 +345,15 @@ public class MarkupWKWebView: WKWebView, ObservableObject {
         }
     }
     
-    //MARK: Keyboard handling and accessoryView setup
-
-    @objc func keyboardWillShow() {
-        markupToolbarHeightConstraint.constant = MarkupEditor.toolbarStyle.height()
-    }
-    
-    @objc private func keyboardDidHide() {
-        markupToolbarHeightConstraint.constant = 0
-    }
+//    //MARK: Keyboard handling and accessoryView setup
+//
+//    @objc func keyboardWillShow() {
+//        markupToolbarHeightConstraint.constant = MarkupEditor.toolbarStyle.height()
+//    }
+//
+//    @objc private func keyboardDidHide() {
+//        markupToolbarHeightConstraint.constant = 0
+//    }
     
     //MARK: Overrides
     

--- a/MarkupEditor/MarkupWKWebViewRepresentable.swift
+++ b/MarkupEditor/MarkupWKWebViewRepresentable.swift
@@ -62,6 +62,10 @@ public struct MarkupWKWebViewRepresentable: UIViewRepresentable {
 
     public func makeUIView(context: Context) -> MarkupWKWebView  {
         let webView = MarkupWKWebView(html: html, placeholder: placeholder, selectAfterLoad: selectAfterLoad, resourcesUrl: resourcesUrl, id: id, markupDelegate: markupDelegate)
+        if MarkupEditor.toolbarLocation == .keyboard {
+            // for the scenario that requires an override of inputAccessoryView
+            webView.inputAccessoryView = MarkupToolbarUIView.inputAccessory(markupDelegate: markupDelegate)
+        }
         // By default, the webView responds to no navigation events unless the navigationDelegate is set
         // during initialization of MarkupEditorUIView.
         webView.navigationDelegate = wkNavigationDelegate


### PR DESCRIPTION
This is to allow the scenario on iOS where we default to the toolbar location position to keyboard accessory view, and a separate override of the toolbar to use a custom version is required to work properly.