### PR TITLE
Refactor to allow override of toolbar for toolbar location keyboard

### DIFF
--- a/MarkupEditor/MarkupEditorUIView.swift
+++ b/MarkupEditor/MarkupEditorUIView.swift
@@ -107,6 +107,8 @@ public class MarkupEditorUIView: UIView, MarkupDelegate {
                     webView.leftAnchor.constraint(equalTo: safeAreaLayoutGuide.leftAnchor),
                     webView.rightAnchor.constraint(equalTo: safeAreaLayoutGuide.rightAnchor)
                 ])
+                // for the scenario that requires an override of inputAccessoryView
+                webView.inputAccessoryView = MarkupToolbarUIView.inputAccessory(markupDelegate: markupDelegate)
             }
         }
     

--- a/MarkupEditor/MarkupToolbarUIView.swift
+++ b/MarkupEditor/MarkupToolbarUIView.swift
@@ -76,7 +76,10 @@ public class MarkupToolbarUIView: UIView {
     /// Return a MarkupToolbarUIView that is compact, containing the current shared ToolbarContents, but makes sure keyboardButton is present.
     public static func inputAccessory(markupDelegate: MarkupDelegate? = nil) -> MarkupToolbarUIView {
         let contents = ToolbarContents.from(ToolbarContents.shared)
-        return MarkupToolbarUIView(.compact, contents: contents, markupDelegate: markupDelegate, withKeyboardButton: true).makeManaged()
+        let toolbar = MarkupToolbarUIView(.compact, contents: contents, markupDelegate: markupDelegate, withKeyboardButton: true).makeManaged()
+        toolbar.translatesAutoresizingMaskIntoConstraints = false
+        toolbar.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        return toolbar
     }
     
 }

--- a/MarkupEditor/MarkupWKWebViewRepresentable.swift
+++ b/MarkupEditor/MarkupWKWebViewRepresentable.swift
@@ -73,6 +73,10 @@ public struct MarkupWKWebViewRepresentable: UIViewRepresentable {
     /// also allows GitHub actions that use the older MacOS version to work, even if you're working locally on Ventura.
     public func makeUIView(context: Context) -> MarkupWKWebView  {
         let webView = MarkupWKWebView(html: html, placeholder: placeholder, selectAfterLoad: selectAfterLoad, resourcesUrl: resourcesUrl, id: id, markupDelegate: markupDelegate)
+        if MarkupEditor.toolbarLocation == .keyboard {
+            // for the scenario that requires an override of inputAccessoryView
+            webView.inputAccessoryView = MarkupToolbarUIView.inputAccessory(markupDelegate: markupDelegate)
+        }
         // By default, the webView responds to no navigation events unless the navigationDelegate is set
         // during initialization of MarkupEditorUIView.
         webView.navigationDelegate = wkNavigationDelegate


### PR DESCRIPTION
From @JohnKuan: This is to allow the scenario on iOS where we default to the toolbar location position to keyboard accessory view, and a separate override of the toolbar to use a custom version is required to work properly.