### PR TITLE
Allow changes to toolbarStyle and toolbarContents on MarkupEditor.swift

### DIFF
--- a/MarkupEditor/MarkupEditor.swift
+++ b/MarkupEditor/MarkupEditor.swift
@@ -26,8 +26,8 @@ public struct MarkupEditor {
         "autocorrect" : "true"
     ]
     public static let markupMenu = MarkupMenu()
-    public static let toolbarContents = ToolbarContents.shared
-    public static let toolbarStyle = ToolbarStyle()
+    public static var toolbarContents = ToolbarContents.shared
+    public static var toolbarStyle = ToolbarStyle()
     public static var toolbarLocation = ToolbarLocation.automatic
     public static var leftToolbar: AnyView? {
         didSet {

--- a/MarkupEditor/ToolbarStyle.swift
+++ b/MarkupEditor/ToolbarStyle.swift
@@ -10,8 +10,8 @@ import UIKit
 @MainActor
 public class ToolbarStyle: @unchecked Sendable, ObservableObject {
     
-    static let compact = ToolbarStyle(.compact)
-    static let labeled = ToolbarStyle(.labeled)
+    public static let compact = ToolbarStyle(.compact)
+    public static let labeled = ToolbarStyle(.labeled)
     
     var style: Style
     


### PR DESCRIPTION
## What

- The README file mentions the allowance to customize the `toolbarStyle` using the `MarkupEditor` struct. However, trying to do so results in a compile error, as the `toolbarStyle` is defined as a constant.
- Also allows changes to the `toolbarContents` 

> You can customize the behavior of the MarkupEditor using the MarkupEditor struct (e.g., MarkupEditor.toolbarStyle = .compact).

<img width="856" height="75" alt="Screenshot 2025-09-24 at 21 09 59" src="https://github.com/user-attachments/assets/8d94ccca-7cfe-4de5-a1a3-503c30045fae" />
