### PR TITLE
Use markupeditor-base 0.8.7 support for focus and blur event callbacks

### DIFF
--- a/MarkupEditor/Resources/markup.js
+++ b/MarkupEditor/Resources/markup.js
@@ -19380,6 +19380,20 @@
   }
 
   /**
+   * Report focus.
+   */
+  function focused() {
+      _callback('focus');
+  }
+
+  /**
+   * Report blur.
+   */
+  function blurred() {
+      _callback('blur');
+  }
+
+  /**
    * Report a change in the ProseMirror document state. The 
    * change might be from typing or formatting or styling, etc.
    * and triggers both a `selectionChanged` and `input` callback.
@@ -23557,6 +23571,8 @@
         // for things things other than the `input` event.
         handleDOMEvents: {
           'input': () => { callbackInput(); },
+          'focus': () => { setTimeout(() => focused());},
+          'blur': () => { setTimeout(() => blurred());},
           'cut': () => { setTimeout(() => { callbackInput(); }, 0); },
           'click': () => { setTimeout(() => { clicked(); }, 0); },
           'delete': () => { setTimeout(() => { callbackInput(); }, 0); },

--- a/markupeditor-js/package-lock.json
+++ b/markupeditor-js/package-lock.json
@@ -20,9 +20,9 @@
       "license": "MIT"
     },
     "node_modules/markupeditor-base": {
-      "version": "0.8.6",
-      "resolved": "https://registry.npmjs.org/markupeditor-base/-/markupeditor-base-0.8.6.tgz",
-      "integrity": "sha512-OXF8k71gqb9nUEcrCqk9cw7QiJ2izFuv+TfHijI6i5B2dEeTDtGwuX3+RU+s4LIodYWFdD5YM/Y9TTBHnSc8rQ==",
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/markupeditor-base/-/markupeditor-base-0.8.7.tgz",
+      "integrity": "sha512-jCQ0v1xH/Se3vYFmA++54+dEh0vBHk94Z1mXDlCU3C6Jqa5gUu2Ewi+dBuKxt/rTIABF4DamvQQDilqWmDcOEw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Swift MarkupEditor will (again) receive focus and blur events