### PR TITLE
Expose allowsInlinePredictions on MarkupWKWebViewConfiguration

### DIFF
--- a/MarkupEditor/MarkupWKWebView.swift
+++ b/MarkupEditor/MarkupWKWebView.swift
@@ -136,7 +136,9 @@ public class MarkupWKWebView: WKWebView, ObservableObject {
     }
     
     public init(html: String? = nil, placeholder: String? = nil, selectAfterLoad: Bool = true, resourcesUrl: URL? = nil, id: String? = nil, markupDelegate: MarkupDelegate? = nil, configuration: MarkupWKWebViewConfiguration? = nil) {
-        super.init(frame: CGRect.zero, configuration: WKWebViewConfiguration())
+        let wkConfiguration = WKWebViewConfiguration()
+        wkConfiguration.allowsInlinePredictions = configuration?.allowsInlinePredictions ?? false
+        super.init(frame: CGRect.zero, configuration: wkConfiguration)
         self.html = html
         self.placeholder = placeholder
         self.selectAfterLoad = selectAfterLoad

--- a/MarkupEditor/MarkupWKWebViewConfiguration.swift
+++ b/MarkupEditor/MarkupWKWebViewConfiguration.swift
@@ -18,9 +18,12 @@ import Foundation
 /// * A CSS file that should be loaded after the MarkupWKWebView has loaded the `markup.css` file. 
 /// The file name is specified and must be provided as part of the app bundle using the MarkupEditor.
 ///
-/// * Top-level attributes for the `editor` element in `markup.html`. By default, the entire `editor` 
+/// * Top-level attributes for the `editor` element in `markup.html`. By default, the entire `editor`
 /// is editable, but will not perform spell check. Autocorrect is enabled by default because without it,
 /// the iOS keyboard will not supply suggestions.
+///
+/// * Whether the underlying WKWebView allows inline predictive text. Off by default, matching the
+/// WKWebViewConfiguration default.
 ///
 /// You create a MarkupWKWebViewConfiguration object in your code, configure its properties, and pass it to the initializer
 /// of your WKWebView object. The web view incorporates your configuration settings only at creation time; you cannot change
@@ -34,6 +37,7 @@ public class MarkupWKWebViewConfiguration {
     public var userCssFile: String? = nil
     public var userResourceFiles: [String]? = nil
     public var topLevelAttributes = EditableAttributes.standard
+    public var allowsInlinePredictions = false
     public var toolbarConfig: ToolbarConfig? = nil
     public var keymapConfig: KeymapConfig? = nil
     public var behaviorConfig: BehaviorConfig? = nil


### PR DESCRIPTION
The default `false` value means there is no effect on existing MarkupEditor consumers, but they can turn it on.